### PR TITLE
Add f-e-d-c support and update modules

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+  "automerge-flathubbot-prs": false,
   "skip-icons-check": true
 }

--- a/org.freedesktop.Sdk.Extension.vala.yml
+++ b/org.freedesktop.Sdk.Extension.vala.yml
@@ -10,7 +10,7 @@ build-options:
   prefix: /usr/lib/sdk/vala
   prepend-pkg-config-path: /usr/lib/sdk/vala/lib/pkgconfig/
   prepend-path: /usr/lib/sdk/vala/bin/
-  cppflags: '-I/usr/lib/sdk/vala/include/'
+  cppflags: -I/usr/lib/sdk/vala/include/
 cleanup:
   - /share/info
   - /share/man
@@ -21,20 +21,36 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/vala/0.56/vala-0.56.0.tar.xz
         sha256: d92bd13c5630905eeb6a983dcb702204da9731460c2a6e4e39f867996f371040
+        x-checker-data:
+          type: gnome
+          name: vala
+          stable-only: true
+          is-main-source: true
     run-tests: true
     modules:
       - name: graphviz
         buildsystem: autotools
         sources:
           - type: archive
-            url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/2.50.0/graphviz-2.50.0.tar.xz
-            sha256: 6b16bf990df114195be669773a1dae975dbbffada45e1de2849ddeb5851bb9a8
-        cleanup: ['/include', '*.pc', '/share/graphviz/doc']
+            url: https://gitlab.com/graphviz/graphviz/-/archive/3.0.0/graphviz-3.0.0.tar.gz
+            sha256: 59931082a3638139e06c296b96e860a9d338432af06f7f57a6ad8da5cbf465c7
+            x-checker-data:
+              type: anitya
+              project-id: 1249
+              stable-only: true
+              url-template: https://gitlab.com/graphviz/graphviz/-/archive/$version/graphviz-$version.tar.gz
+        cleanup: [/include, '*.pc', /share/graphviz/doc]
       - name: dbus-run-session
         sources:
           - type: git
             url: https://gitlab.freedesktop.org/dbus/dbus
-            tag: dbus-1.13.22
+            tag: dbus-1.14.0
+            x-checker-data:
+              type: anitya
+              project-id: 5356
+              stable-only: true
+              tag-template: dbus-$version
+            commit: 6fd1509ba3677ac434176882fbf1ca5d7603651e
         buildsystem: autotools
         cleanup: ['*']
       - name: include-dir
@@ -47,22 +63,36 @@ modules:
       - type: git
         url: https://github.com/Prince781/vala-language-server.git
         tag: 0.48.4
+        x-checker-data:
+          type: anitya
+          project-id: 242051
+          stable-only: true
+          tag-template: $version
+        commit: bbc824697b67d4db452ba7d43ade245902756d11
     build-options:
-      env: {'XDG_DATA_DIRS': '/usr/lib/sdk/vala/share/' }
+      env: {XDG_DATA_DIRS: /usr/lib/sdk/vala/share/}
     modules:
       - name: jsonrpc
         buildsystem: meson
         sources:
           - type: archive
-            url: https://download.gnome.org/sources/jsonrpc-glib/3.41/jsonrpc-glib-3.41.0.tar.xz
-            sha256: 7c4e6a5b8c3729632cecc312dc1163c4d00243d32e90528e54ec5038a23a7c21
-        cleanup: ['/include', '*.pc', '*.gir', '*.typelib']
+            url: https://download.gnome.org/sources/jsonrpc-glib/3.42/jsonrpc-glib-3.42.0.tar.xz
+            sha256: 221989a57ca82a12467dc427822cd7651b0cad038140c931027bf1074208276b
+            x-checker-data:
+              type: gnome
+              name: jsonrpc-glib
+              stable-only: true
+        cleanup: [/include, '*.pc', '*.gir', '*.typelib']
       - name: gee
         buildsystem: autotools
         sources:
           - type: archive
             url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.5.tar.xz
             sha256: 31863a8957d5a727f9067495cabf0a0889fa5d3d44626e54094331188d5c1518
+            x-checker-data:
+              type: gnome
+              name: libgee
+              stable-only: true
   - name: scripts
     buildsystem: simple
     sources:


### PR DESCRIPTION
Changes
- Add flatpak-external-data-checker properties for update automation of sources.
- Avoid auto-merging pull requests opened by flathubbot.
- Update modules with f-e-d-c to latest releases
  - graphviz 3.0.0
  - dbus 1.14.0
  - jsonrpc-glib 3.42.0
- Cosmetics changes made by f-e-d-c