### PR TITLE
Don't clean /share/aclocal

### DIFF
--- a/org.freedesktop.Sdk.Extension.vala.yml
+++ b/org.freedesktop.Sdk.Extension.vala.yml
@@ -16,7 +16,6 @@ cleanup:
   - /share/doc
   - /share/gir-1.0
   - /lib/girepository-1.0
-  - /share/aclocal
   - /include
   - /lib/pkgconfig
   - '*.la'


### PR DESCRIPTION
Without the autoconf macros, we have no chance of building autotools projects that depend on vala. Missing macros result in exceptionally confusing error messages. For example, this error when building libgee:

./configure: line 13551: syntax error near unexpected token `fi'
./configure: line 13551: `fi'

This is going to affect almost all Vala applications, except for the few that do not use libgee, because it's no longer provided by the runtime and it uses Autotools.