### PR TITLE
Update graphviz, dbus-run-session, valac, jsonrpc and 2 more modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.vala.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.vala.appdata.xml
@@ -2,12 +2,8 @@
 <!-- Copyright 2022 Lorenz Wildberg <lorenz@wild-fisch.de> -->
 <component type="addon">
   <extends>org.freedesktop.Sdk</extends>
-  <id>
-    org.freedesktop.Sdk.Extension.vala
-  </id>
-  <metadata_license>
-    CC0-1.0
-  </metadata_license>
+  <id>org.freedesktop.Sdk.Extension.vala</id>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>
     Vala Sdk extension
   </name>
@@ -19,16 +15,13 @@
       Vala is a programming language using modern high level abstractions without imposing additional runtime requirements and without using a different ABI compared to applications and libraries written in C. Vala uses the GObject type system and has additional code generation routines that make targeting the GNOME stack simple. Vala has many other uses where native binaries are required.
     </p>
   </description>
-  <project_license>
-    LGPL-2.1-only
-  </project_license>
+  <project_license>LGPL-2.1-only</project_license>
   <url type="homepage">
     https://wiki.gnome.org/Projects/Vala/
   </url>
   <url type="bugtracker">
     https://gitlab.gnome.org/GNOME/vala/-/issues
   </url>
-  <translation/>
   <update_contact>
     lorenz@wild-fisch.de
   </update_contact>

--- a/org.freedesktop.Sdk.Extension.vala.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.vala.appdata.xml
@@ -33,6 +33,9 @@
     lorenz@wild-fisch.de
   </update_contact>
   <releases>
+    <release version="0.56.18" date="2025-03-18">
+      <description></description>
+    </release>
     <release version="0.56.17" date="2024-04-19"/>
     <release version="0.56.16" date="2024-03-14"/>
     <release version="0.56.15" date="2024-03-04"/>

--- a/org.freedesktop.Sdk.Extension.vala.yml
+++ b/org.freedesktop.Sdk.Extension.vala.yml
@@ -25,8 +25,8 @@ modules:
     buildsystem: autotools
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/vala/0.56/vala-0.56.17.tar.xz
-        sha256: 26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a
+        url: https://download.gnome.org/sources/vala/0.56/vala-0.56.18.tar.xz
+        sha256: f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382
         x-checker-data:
           type: gnome
           name: vala
@@ -41,8 +41,8 @@ modules:
         buildsystem: autotools
         sources:
           - type: archive
-            url: https://gitlab.com/graphviz/graphviz/-/archive/10.0.1/graphviz-10.0.1.tar.gz
-            sha256: 28f452ef1cb12288c8758a62f8c3fcfefdb91b251f7aae61d0d703f851bde931
+            url: https://gitlab.com/graphviz/graphviz/-/archive/12.2.1/graphviz-12.2.1.tar.gz
+            sha256: 91d444b4dabdaf5bfa7c6fcc3a1ee5d41e588af6079ebc030f0acb79e48a56ea
             x-checker-data:
               type: anitya
               project-id: 1249
@@ -51,17 +51,19 @@ modules:
               is-important: false
         cleanup: [/share/graphviz/doc, /bin, /lib/pkgconfig]
       - name: dbus-run-session
+        config-opts:
+          - -Dsystemd=disabled
         sources:
           - type: archive
-            url: https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-1.14.10/dbus-dbus-1.14.10.tar.gz
-            sha256: 5fedcd6c17fbc62646af224e1aab11a334c463e7e7d89163a670ed24e7ab241c
+            url: https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-1.16.2/dbus-dbus-1.16.2.tar.gz
+            sha256: d77cc71acd93e85f2bd2a6fe3a40e5bd023519e3e9fa9b5361e7109f42b74060
             x-checker-data:
               type: anitya
               project-id: 5356
               stable-only: true
               url-template: https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-$version/dbus-dbus-$version.tar.gz
               is-important: false
-        buildsystem: autotools
+        buildsystem: meson
         cleanup: ['*']
   - name: vls
     buildsystem: meson
@@ -82,8 +84,8 @@ modules:
         buildsystem: meson
         sources:
           - type: archive
-            url: https://download.gnome.org/sources/jsonrpc-glib/3.44/jsonrpc-glib-3.44.0.tar.xz
-            sha256: 69406a0250d0cc5175408cae7eca80c0c6bfaefc4ae1830b354c0433bcd5ce06
+            url: https://download.gnome.org/sources/jsonrpc-glib/3.44/jsonrpc-glib-3.44.1.tar.xz
+            sha256: 1361d17e9c805646afe5102e59baf8ca450238600fcabd01586c654b78bb30df
             x-checker-data:
               type: gnome
               name: jsonrpc-glib
@@ -97,8 +99,8 @@ modules:
           cflags: -Wno-error=incompatible-pointer-types
         sources:
           - type: archive
-            url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.6.tar.xz
-            sha256: 1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d
+            url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.8.tar.xz
+            sha256: 189815ac143d89867193b0c52b7dc31f3aa108a15f04d6b5dca2b6adfad0b0ee
             x-checker-data:
               type: gnome
               name: libgee
@@ -112,8 +114,8 @@ modules:
         builddir: true
         sources:
           - type: archive
-            url: https://github.com/uncrustify/uncrustify/archive/uncrustify-0.78.1.tar.gz
-            sha256: ecaf4c0adca14c36dfffa30bc28e69865115ecd602c90eb16a8cddccb41caad2
+            url: https://github.com/uncrustify/uncrustify/archive/uncrustify-0.80.1.tar.gz
+            sha256: 0e2616ec2f78e12816388c513f7060072ff7942b42f1175eb28b24cb75aaec48
             x-checker-data:
               type: anitya
               project-id: 5043


### PR DESCRIPTION
graphviz: Update graphviz-10.0.1.tar.gz to 12.2.1
dbus-run-session: Update dbus-dbus-1.14.10.tar.gz to 1.16.2
valac: Update vala-0.56.17.tar.xz to 0.56.18
jsonrpc: Update jsonrpc-glib-3.44.0.tar.xz to 3.44.1
gee: Update libgee-0.20.6.tar.xz to 0.20.8
uncrustify: Update uncrustify-0.78.1.tar.gz to 0.80.1